### PR TITLE
docs: refresh README with product workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,100 +1,240 @@
-# Soku CLI
+<div align="center">
+  <a href="https://soku.ai">
+    <img src="./assets/soku-mark.svg" alt="Soku" width="104" />
+  </a>
+  <h1>Soku CLI</h1>
+  <p><strong>Give any AI agent a secure command line to your growth stack.</strong></p>
+  <p>
+    Query marketing data, manage campaigns, publish SEO content, and automate<br />
+    recurring work from Claude Code, Codex, Cursor, or any terminal.
+  </p>
+  <p>
+    <a href="https://www.npmjs.com/package/@soku-ai/cli"><img src="https://img.shields.io/npm/v/@soku-ai/cli?color=ff6b00&amp;label=npm" alt="npm version" /></a>
+    <a href="https://nodejs.org/"><img src="https://img.shields.io/badge/Node.js-%3E%3D20-339933?logo=node.js&amp;logoColor=white" alt="Node.js 20 or newer" /></a>
+    <a href="./LICENSE"><img src="https://img.shields.io/badge/license-MIT-black.svg" alt="MIT license" /></a>
+  </p>
+  <p>
+    <a href="https://soku.ai">Website</a> ·
+    <a href="https://soku.ai/cli/skill.md">Agent guide</a> ·
+    <a href="https://www.npmjs.com/package/@soku-ai/cli">npm</a> ·
+    <a href="./CONTRIBUTING.md">Contributing</a>
+  </p>
+</div>
 
-[![npm](https://img.shields.io/npm/v/@soku-ai/cli.svg)](https://www.npmjs.com/package/@soku-ai/cli)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+---
 
-`soku` is the shell-native way for an AI agent — Claude Code, Codex, Cursor, or
-any terminal — to use [Soku](https://soku.ai): auth, workspace selection,
-Google Ads / GA4 / PostHog data reads, typed ads writes, SEO Hosting,
-automations, Context Hub files, third-party egress, and skill management. It
-talks to Soku over `/api/cli/*`; no MCP host is required.
+Soku CLI turns the tools and data already connected to your Soku workspace into
+typed, discoverable commands. An agent can move from a question to an answer—or
+from a plan to a human-approved action—without you copying data between tabs,
+sharing API keys, or running an MCP host.
 
-## Install
+## Why Soku CLI?
 
-```bash
-npm install -g @soku-ai/cli
-# or run without installing
-npx @soku-ai/cli --help
-```
+- **One interface for your growth stack.** Work with Google Ads, Meta Ads,
+  ChatGPT Ads, GA4, PostHog, SEO Hosting, automations, Context Hub, and more.
+- **Built for agents, useful in a shell.** Commands are self-documenting, and
+  non-interactive output uses a stable JSON envelope that agents and scripts can
+  parse reliably.
+- **Credentials stay out of prompts.** Soku handles authentication and can inject
+  connected third-party credentials server-side.
+- **Writes have a human gate.** Delivery-changing ads operations create a review
+  request before anything goes live.
+- **New capabilities arrive automatically.** The typed command tree is generated
+  from Soku's capability registry, with `soku call` as a forward-compatible
+  escape hatch.
 
-Requires Node.js >= 20.
+## Quick start
 
-## Use it from an AI agent (recommended)
+### Let your AI agent set it up (recommended)
 
-The fastest way to onboard is to let your coding agent (Claude Code, Codex,
-Cursor, …) drive the whole setup. Paste this prompt:
+Paste this into Claude Code, Codex, Cursor, or another coding agent:
 
-```
+```text
 Read https://soku.ai/cli/skill.md, install or update Soku CLI, sign in,
 select my workspace, and install all business skills.
 ```
 
-`https://soku.ai/cli/skill.md` is an agent-facing Markdown manual. The agent
-will install/update `@soku-ai/cli`, run the split-flow device login
-(`soku auth login --no-wait`), select your Soku workspace
-(`soku workspace resolve` / `use-brand`), install the bundled `soku` meta skill,
-and run `soku skill install --all --global` to add every business skill. It then
-verifies with `ads` / `ga4` / `egress providers` / `seo-hosting status`.
+The agent guide walks the agent through installation, device login, workspace
+selection, skill installation, and a first capability check.
 
-The bundled skill lives at [`skills/soku/SKILL.md`](./skills/soku/SKILL.md).
-
-## Manual setup (shell)
+### Set it up manually
 
 ```bash
-# 1. Authenticate (device flow — opens a browser / prints a QR code).
-#    For agents / non-interactive shells, use: soku auth login --no-wait
+# Install globally (Node.js 20+)
+npm install -g @soku-ai/cli
+
+# Sign in with the browser-based device flow
 soku auth login
 
-# 2. Pick your workspace (org + brand)
-soku workspace resolve <brand>     # find a brand you can access
-soku workspace use-brand <brand>   # switch to it
-soku workspace status              # confirm the active workspace
+# Find and select a Soku brand workspace
+soku workspace resolve <brand>
+soku workspace use-brand <brand>
+soku workspace status
 
-# 3. (optional) install the business skills
-soku skill install --all --global
-
-# 4. Discover capabilities and make a call
+# See everything available to you
 soku --help
-soku ads --help                    # list ads subcommands (e.g. get-google-ads-report)
 ```
 
-## Output
+No global install needed? Start with `npx @soku-ai/cli --help`.
 
-In non-interactive (non-TTY) contexts the CLI emits a stable JSON envelope, so
-agents and scripts can parse results deterministically:
+## What can you do with it?
 
-- success → `{"ok":true,"data":...}`
-- error → `{"ok":false,"error":...}` (with a non-zero exit code)
+### Turn ad data into answers
 
-## Capability model
+Start with cached, normalized reporting across supported ad platforms:
 
-The CLI's typed command tree is generated from a capability manifest at
-[`src/generated/capabilities.json`](./src/generated/capabilities.json). **This
-file is generated upstream and synced into this repository automatically — do
-not hand-edit it.** New capabilities appear here when the Soku backend adds
-them; a change to the backend's capability surface triggers an automated PR that
-updates this file. See [CONTRIBUTING.md](./CONTRIBUTING.md) for details.
+```bash
+soku ads list-ad-accounts --platform google
+
+soku ads query-single-dimension \
+  --platform google \
+  --account-id <account_id> \
+  --dimension campaign \
+  --date-start 2026-06-01 \
+  --date-end 2026-06-30
+```
+
+Use the same workflow for Meta, TikTok, or ChatGPT Ads, or reach for Google Ads
+GAQL when you need a custom breakdown.
+
+### Understand acquisition and product behavior together
+
+```bash
+# Website acquisition and conversion
+soku ga4 list-properties
+soku ga4 get-property-overview --property-id <property_id>
+soku ga4 list-traffic-sources --property-id <property_id>
+
+# Product behavior
+soku posthog list-projects
+soku posthog query \
+  --project-id <project_id> \
+  --tool execute-sql \
+  --arguments '{"query":"SELECT count() FROM events WHERE event = '\''$pageview'\''"}'
+```
+
+This makes it possible for an agent to investigate the path from campaign spend
+to site traffic to in-product behavior without asking you to export CSV files.
+
+### Create campaign changes with a human in control
+
+```bash
+soku ads meta campaign create \
+  --account-id <meta_account_id> \
+  --name "Launch Test" \
+  --objective OUTCOME_TRAFFIC \
+  --summary "Create paused Meta traffic campaign Launch Test"
+```
+
+Delivery-changing writes return a review ID instead of executing immediately:
+
+```bash
+soku review show <review_id>
+soku review approve <review_id>
+```
+
+An agent can prepare the exact change and explain it; a human still decides
+whether it runs.
+
+### Publish and automate growth work
+
+```bash
+# Publish a complete HTML page through Soku SEO Hosting
+soku seo-hosting pages put \
+  --section blog \
+  --slug launch-notes \
+  --title "Launch notes" \
+  --html-file page.html
+soku seo-hosting pages publish --section blog --slug launch-notes
+
+# Schedule a recurring agent task
+soku automation create \
+  --name "Weekly account health" \
+  --prompt "Review paid acquisition performance and flag anomalies" \
+  --cron "0 9 * * 1" \
+  --timezone America/Los_Angeles
+
+# Add source material to the workspace Context Hub
+soku context upload ./campaign-brief.pdf --dir research
+```
+
+## Agent-native by design
+
+In a non-interactive shell, every command returns a predictable JSON envelope:
+
+```json
+{"ok":true,"data":{"...":"..."}}
+```
+
+Errors use the same shape and a non-zero exit code:
+
+```json
+{"ok":false,"error":{"code":"...","message":"..."}}
+```
+
+Install Soku's agent skills to give your agent the workflows and guardrails
+behind the commands—not just their names:
+
+```bash
+soku skill install --all --global
+soku skill list
+soku skill status
+```
+
+The bundled meta skill is available at [`skills/soku/SKILL.md`](./skills/soku/SKILL.md).
+
+## Command map
+
+| Area | Start here | Typical use |
+| --- | --- | --- |
+| Authentication | `soku auth --help` | Sign in, sign out, and check session state |
+| Workspace | `soku workspace --help` | Resolve and switch organization/brand context |
+| Advertising | `soku ads --help` | Query reporting data and prepare reviewed writes |
+| Analytics | `soku ga4 --help`, `soku posthog --help` | Analyze acquisition, conversion, and product behavior |
+| SEO Hosting | `soku seo-hosting --help` | Stage, publish, and manage SEO pages and domains |
+| Automations | `soku automation --help` | Schedule and inspect recurring agent work |
+| Context Hub | `soku context --help` | Organize files an agent can use as context |
+| Secure egress | `soku egress --help` | Call supported third-party APIs without exposing keys |
+| Reviews | `soku review --help` | Inspect and decide on gated operations |
+| Skills | `soku skill --help` | Install and update Soku workflows for AI agents |
+
+Run `soku <namespace> <action> --help` before an unfamiliar call. Typed command
+names use kebab-case; raw capability names used with `soku call` use snake_case.
+
+## How it works
+
+The CLI talks to Soku over `/api/cli/*`; it does not require an MCP host. Its
+typed commands are generated from
+[`src/generated/capabilities.json`](./src/generated/capabilities.json), which is
+synced automatically from the Soku backend. Do not edit that file by hand.
+
+If a newly released capability does not yet have an ergonomic typed command,
+you can still discover it and call it directly:
+
+```bash
+soku call ads list_ad_accounts -p platform=google
+soku call <namespace> <action> --help
+```
 
 ## Development
 
 ```bash
-pnpm install        # installs deps (uses the pinned pnpm version)
-pnpm typecheck      # tsc --noEmit
-pnpm test           # compile + node:test runner
-pnpm build          # emit dist/ + copy the capability manifest
+pnpm install
+pnpm typecheck
+pnpm test
+pnpm build
 ```
 
-- Source: `src/` (TypeScript, ESM, `NodeNext` module resolution)
-- Tests: colocated `*.test.ts`, run with the built-in `node --test` runner
-- `keytar` is an optional dependency — credential storage degrades gracefully to
-  a file-backed store when the native module is unavailable.
+The project is TypeScript with ESM and `NodeNext` module resolution. Tests are
+colocated as `*.test.ts` files and run with Node's built-in test runner.
+`keytar` is optional; when it is unavailable, credential storage falls back to
+a file-backed store.
 
 ## Contributing
 
-Issues and pull requests are welcome. Please read
-[CONTRIBUTING.md](./CONTRIBUTING.md) and our
-[Code of Conduct](./CODE_OF_CONDUCT.md) first. For security reports, see
-[SECURITY.md](./SECURITY.md).
+Issues and pull requests are welcome. Read [CONTRIBUTING.md](./CONTRIBUTING.md)
+and our [Code of Conduct](./CODE_OF_CONDUCT.md) before contributing. Please use
+[SECURITY.md](./SECURITY.md) to report security issues.
 
 ## License
 

--- a/assets/soku-mark.svg
+++ b/assets/soku-mark.svg
@@ -1,0 +1,14 @@
+<svg width="1700" height="1700" viewBox="0 0 1700 1700" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M1337.46 506.487C1360.7 546.743 1346.91 598.219 1306.66 621.461L750.378 942.627C629.609 1012.35 475.183 970.975 405.457 850.206C335.731 729.437 377.109 575.011 497.878 505.285L762.593 352.451C963.875 236.241 1221.25 305.205 1337.46 506.487Z" fill="url(#top)"/>
+  <path d="M363.29 1194.43C340.048 1154.17 353.841 1102.69 394.097 1079.45L950.374 758.285C1071.14 688.559 1225.57 729.937 1295.3 850.706C1365.02 971.475 1323.64 1125.9 1202.87 1195.63L938.159 1348.46C736.878 1464.67 479.5 1395.71 363.29 1194.43Z" fill="url(#bottom)"/>
+  <defs>
+    <linearGradient id="top" x1="745.126" y1="876.785" x2="997.626" y2="1314.13" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF6400"/>
+      <stop offset="1" stop-color="#FF6E00"/>
+    </linearGradient>
+    <linearGradient id="bottom" x1="745.126" y1="876.785" x2="997.626" y2="1314.13" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FF7E00"/>
+      <stop offset="1" stop-color="#FF7600"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
## Summary

- add the official Soku mark and a clearer agent-first product positioning
- explain practical value across ads, analytics, SEO Hosting, and automations
- add verified setup, workflow, review-gate, JSON output, and command-map examples

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / chore
- [x] Documentation

## Checklist

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes
- [x] I did **not** hand-edit `src/generated/capabilities.json` (it is synced from upstream)
- [x] Commits follow Conventional Commits
- [x] Added/updated tests for behavior changes — not applicable; documentation-only change