### PR TITLE
fix: parse glued --flag=value curl args in egress

### DIFF
--- a/src/commands/egress.test.ts
+++ b/src/commands/egress.test.ts
@@ -64,6 +64,11 @@ test('keeps a --data value that itself looks like a recognized glued option', ()
   assert.equal(r.body?.toString(), '--url=https://payload.invalid')
 })
 
+test('--data-raw keeps a literal @ payload instead of reading a file', () => {
+  const r = parseCurl(['curl', 'https://x.test/a', '--data-raw=@/no/such/soku-egress-test'])
+  assert.equal(r.body?.toString(), '@/no/such/soku-egress-test')
+})
+
 test('-G folds data into the query string', () => {
   const r = parseCurl(['curl', '-G', 'https://x.test/a', '-d', 'q=hello&n=2'])
   assert.equal(r.method, 'GET')

--- a/src/commands/egress.test.ts
+++ b/src/commands/egress.test.ts
@@ -57,6 +57,13 @@ test('does not split a value that looks like a glued flag', () => {
   assert.equal(r.body?.toString(), '--foo=bar')
 })
 
+test('keeps a --data value that itself looks like a recognized glued option', () => {
+  const r = parseCurl(['curl', '--data', '--url=https://payload.invalid', 'https://target.invalid'])
+  assert.equal(r.method, 'POST')
+  assert.equal(r.url, 'https://target.invalid')
+  assert.equal(r.body?.toString(), '--url=https://payload.invalid')
+})
+
 test('-G folds data into the query string', () => {
   const r = parseCurl(['curl', '-G', 'https://x.test/a', '-d', 'q=hello&n=2'])
   assert.equal(r.method, 'GET')

--- a/src/commands/egress.test.ts
+++ b/src/commands/egress.test.ts
@@ -47,6 +47,16 @@ test('splits glued --header on the first = only', () => {
   assert.equal(r.headers['x-foo'], 'a=b')
 })
 
+test('does not expand glued unknown options over the real url', () => {
+  const r = parseCurl(['curl', 'https://api.example/real', '--referer=https://ref.example'])
+  assert.equal(r.url, 'https://api.example/real')
+})
+
+test('does not split a value that looks like a glued flag', () => {
+  const r = parseCurl(['curl', 'https://x.test/a', '--data', '--foo=bar'])
+  assert.equal(r.body?.toString(), '--foo=bar')
+})
+
 test('-G folds data into the query string', () => {
   const r = parseCurl(['curl', '-G', 'https://x.test/a', '-d', 'q=hello&n=2'])
   assert.equal(r.method, 'GET')

--- a/src/commands/egress.test.ts
+++ b/src/commands/egress.test.ts
@@ -34,6 +34,19 @@ test('accepts --url and is tolerant of unknown flags', () => {
   assert.equal(r.headers['x-key'], 'v')
 })
 
+test('parses glued --flag=value the same as the space form', () => {
+  const r = parseCurl(['curl', '--request=POST', '--url=https://x.test/a', '--header=X-Key: v', '--data={"a":1}'])
+  assert.equal(r.method, 'POST')
+  assert.equal(r.url, 'https://x.test/a')
+  assert.equal(r.headers['x-key'], 'v')
+  assert.equal(r.body?.toString(), '{"a":1}')
+})
+
+test('splits glued --header on the first = only', () => {
+  const r = parseCurl(['curl', '--url=https://x.test/a', '--header=X-Foo: a=b'])
+  assert.equal(r.headers['x-foo'], 'a=b')
+})
+
 test('-G folds data into the query string', () => {
   const r = parseCurl(['curl', '-G', 'https://x.test/a', '-d', 'q=hello&n=2'])
   assert.equal(r.method, 'GET')

--- a/src/commands/egress.ts
+++ b/src/commands/egress.ts
@@ -37,8 +37,24 @@ function readData(value: string): Buffer {
   return Buffer.from(value)
 }
 
+/** Expand glued long options (`--flag=value`) into `--flag`, `value` so both
+ * curl forms parse the same. Splits on the first `=` only. Pure. */
+function expandLongFlags(tokens: string[]): string[] {
+  const out: string[] = []
+  for (const t of tokens) {
+    if (t.startsWith('--') && t.includes('=')) {
+      const eq = t.indexOf('=')
+      out.push(t.slice(0, eq), t.slice(eq + 1))
+    } else {
+      out.push(t)
+    }
+  }
+  return out
+}
+
 /** Extract method / url / headers / body from a curl-style token list. Pure. */
-export function parseCurl(tokens: string[]): ParsedCurl {
+export function parseCurl(input: string[]): ParsedCurl {
+  const tokens = expandLongFlags(input)
   const headers: Record<string, string> = {}
   let method: string | undefined
   let url: string | undefined

--- a/src/commands/egress.ts
+++ b/src/commands/egress.ts
@@ -76,9 +76,15 @@ export function parseCurl(tokens: string[]): ParsedCurl {
         }
         break
       }
+      case '--data-raw': {
+        // curl's --data-raw is the one data option that does NOT treat a
+        // leading `@` as a filename; the payload is sent verbatim.
+        const d = inline ?? tokens[++i]
+        if (d !== undefined) body = Buffer.from(d)
+        break
+      }
       case '-d':
       case '--data':
-      case '--data-raw':
       case '--data-ascii':
       case '--data-binary': {
         const d = inline ?? tokens[++i]

--- a/src/commands/egress.ts
+++ b/src/commands/egress.ts
@@ -37,31 +37,14 @@ function readData(value: string): Buffer {
   return Buffer.from(value)
 }
 
-// Long options we consume as `--flag value`; only these are worth un-gluing.
-// Restricting the split keeps us from mangling an unknown option's value into a
-// stray token (e.g. `--referer=https://x` would otherwise clobber the target
-// url) or from splitting a value that happens to look like `--foo=bar`.
+// Long options we consume as `--flag value` and therefore also accept in the
+// glued `--flag=value` form. We un-glue these during parsing (below), not in a
+// pre-pass, so a value that merely looks like a glued option (e.g. the argument
+// to --data) is never split out of its value position.
 const GLUED_OPTS = new Set(['--request', '--header', '--data', '--data-raw', '--data-ascii', '--data-binary', '--url'])
 
-/** Expand glued long options (`--flag=value`) into `--flag`, `value` so both
- * curl forms parse the same, but only for options we actually recognize.
- * Splits on the first `=` only. Pure. */
-function expandLongFlags(tokens: string[]): string[] {
-  const out: string[] = []
-  for (const t of tokens) {
-    const eq = t.indexOf('=')
-    if (eq > 2 && t.startsWith('--') && GLUED_OPTS.has(t.slice(0, eq))) {
-      out.push(t.slice(0, eq), t.slice(eq + 1))
-    } else {
-      out.push(t)
-    }
-  }
-  return out
-}
-
 /** Extract method / url / headers / body from a curl-style token list. Pure. */
-export function parseCurl(input: string[]): ParsedCurl {
-  const tokens = expandLongFlags(input)
+export function parseCurl(tokens: string[]): ParsedCurl {
   const headers: Record<string, string> = {}
   let method: string | undefined
   let url: string | undefined
@@ -70,15 +53,23 @@ export function parseCurl(input: string[]): ParsedCurl {
 
   let i = tokens[0] === 'curl' ? 1 : 0
   for (; i < tokens.length; i++) {
-    const t = tokens[i]
+    const raw = tokens[i]
+    // Un-glue `--flag=value` only when this token is itself in option position
+    // and names an option we consume; then read the value inline instead of
+    // consuming the next token. A token like the `--url=x` argument to --data is
+    // never in option position, so it stays intact. Splits on the first `=`.
+    const eq = raw.indexOf('=')
+    const glued = eq > 2 && raw.startsWith('--') && GLUED_OPTS.has(raw.slice(0, eq))
+    const t = glued ? raw.slice(0, eq) : raw
+    const inline = glued ? raw.slice(eq + 1) : undefined
     switch (t) {
       case '-X':
       case '--request':
-        method = tokens[++i]?.toUpperCase()
+        method = (inline ?? tokens[++i])?.toUpperCase()
         break
       case '-H':
       case '--header': {
-        const h = tokens[++i]
+        const h = inline ?? tokens[++i]
         if (h) {
           const idx = h.indexOf(':')
           if (idx > 0) headers[h.slice(0, idx).trim().toLowerCase()] = h.slice(idx + 1).trim()
@@ -90,7 +81,7 @@ export function parseCurl(input: string[]): ParsedCurl {
       case '--data-raw':
       case '--data-ascii':
       case '--data-binary': {
-        const d = tokens[++i]
+        const d = inline ?? tokens[++i]
         if (d !== undefined) body = readData(d)
         break
       }
@@ -99,7 +90,7 @@ export function parseCurl(input: string[]): ParsedCurl {
         getMode = true
         break
       case '--url':
-        url = tokens[++i]
+        url = inline ?? tokens[++i]
         break
       default:
         if (/^https?:\/\//i.test(t)) url = t

--- a/src/commands/egress.ts
+++ b/src/commands/egress.ts
@@ -37,13 +37,20 @@ function readData(value: string): Buffer {
   return Buffer.from(value)
 }
 
+// Long options we consume as `--flag value`; only these are worth un-gluing.
+// Restricting the split keeps us from mangling an unknown option's value into a
+// stray token (e.g. `--referer=https://x` would otherwise clobber the target
+// url) or from splitting a value that happens to look like `--foo=bar`.
+const GLUED_OPTS = new Set(['--request', '--header', '--data', '--data-raw', '--data-ascii', '--data-binary', '--url'])
+
 /** Expand glued long options (`--flag=value`) into `--flag`, `value` so both
- * curl forms parse the same. Splits on the first `=` only. Pure. */
+ * curl forms parse the same, but only for options we actually recognize.
+ * Splits on the first `=` only. Pure. */
 function expandLongFlags(tokens: string[]): string[] {
   const out: string[] = []
   for (const t of tokens) {
-    if (t.startsWith('--') && t.includes('=')) {
-      const eq = t.indexOf('=')
+    const eq = t.indexOf('=')
+    if (eq > 2 && t.startsWith('--') && GLUED_OPTS.has(t.slice(0, eq))) {
       out.push(t.slice(0, eq), t.slice(eq + 1))
     } else {
       out.push(t)


### PR DESCRIPTION
`soku egress` wraps a real curl command, but `parseCurl` only matched the space-separated flag form. curl also accepts the glued `--flag=value` form, which fell through and was dropped (`--url=` → "no url found"; `--header=` / `--data=` dropped silently).

fix: expand `--flag=value` into `--flag`, `value` before parsing. added tests.

    soku egress -- curl --url=https://x/    # before: "no url found"
    soku egress -- curl --url https://x/    # works today