### PR TITLE
feat: soku live-surfaces — hand a person a live link to your work

### DIFF
--- a/src/commands/live-surface.test.ts
+++ b/src/commands/live-surface.test.ts
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { Command } from 'commander'
+
+import { registerLiveSurfaceCommands } from './live-surface.js'
+
+function findCommand(root: Command, ...path: string[]): Command {
+  let current = root
+  for (const name of path) {
+    const next = current.commands.find((cmd) => cmd.name() === name)
+    assert.ok(next, `missing command path ${path.join(' ')}`)
+    current = next
+  }
+  return current
+}
+
+test('live-surfaces exposes the four operations the server routes offer', () => {
+  // The server surface shipped before this command did, so the docs and the
+  // dispatcher's refusal message pointed at `soku live-surfaces` while nothing
+  // by that name existed. Each of these has a route behind it.
+  const program = new Command()
+  registerLiveSurfaceCommands(program)
+
+  for (const name of ['open', 'list', 'revoke', 'rotate-credential']) {
+    const command = findCommand(program, 'live-surfaces', name)
+    assert.ok(command.description(), `${name} has no description`)
+  }
+})
+
+test('open can hand over a link that cannot be edited or approved from', () => {
+  // A preview link is the right shape when showing work rather than inviting
+  // changes, and `--no-approvals` is what withholds the credential entirely.
+  const program = new Command()
+  registerLiveSurfaceCommands(program)
+  const open = findCommand(program, 'live-surfaces', 'open')
+
+  const flags = open.options.map((option) => option.long)
+  assert.ok(flags.includes('--read-only'))
+  assert.ok(flags.includes('--no-approvals'))
+  assert.ok(flags.includes('--ttl-hours'))
+})
+
+test('revoking a link and rotating its code are separate commands', () => {
+  // A credential seen by the wrong person should not cost the right person
+  // their work surface, so rotating never revokes.
+  const program = new Command()
+  registerLiveSurfaceCommands(program)
+
+  const revoke = findCommand(program, 'live-surfaces', 'revoke')
+  const rotate = findCommand(program, 'live-surfaces', 'rotate-credential')
+
+  assert.notEqual(revoke.name(), rotate.name())
+  assert.match(rotate.description(), /leaving the link itself alive/i)
+})

--- a/src/commands/live-surface.test.ts
+++ b/src/commands/live-surface.test.ts
@@ -15,15 +15,15 @@ function findCommand(root: Command, ...path: string[]): Command {
   return current
 }
 
-test('live-surfaces exposes the four operations the server routes offer', () => {
+test('live exposes the four operations the server routes offer', () => {
   // The server surface shipped before this command did, so the docs and the
-  // dispatcher's refusal message pointed at `soku live-surfaces` while nothing
+  // dispatcher's refusal message pointed at `soku live` while nothing
   // by that name existed. Each of these has a route behind it.
   const program = new Command()
   registerLiveSurfaceCommands(program)
 
   for (const name of ['open', 'list', 'revoke', 'rotate-credential']) {
-    const command = findCommand(program, 'live-surfaces', name)
+    const command = findCommand(program, 'live', name)
     assert.ok(command.description(), `${name} has no description`)
   }
 })
@@ -33,7 +33,7 @@ test('open can hand over a link that cannot be edited or approved from', () => {
   // changes, and `--no-approvals` is what withholds the credential entirely.
   const program = new Command()
   registerLiveSurfaceCommands(program)
-  const open = findCommand(program, 'live-surfaces', 'open')
+  const open = findCommand(program, 'live', 'open')
 
   const flags = open.options.map((option) => option.long)
   assert.ok(flags.includes('--read-only'))
@@ -47,8 +47,8 @@ test('revoking a link and rotating its code are separate commands', () => {
   const program = new Command()
   registerLiveSurfaceCommands(program)
 
-  const revoke = findCommand(program, 'live-surfaces', 'revoke')
-  const rotate = findCommand(program, 'live-surfaces', 'rotate-credential')
+  const revoke = findCommand(program, 'live', 'revoke')
+  const rotate = findCommand(program, 'live', 'rotate-credential')
 
   assert.notEqual(revoke.name(), rotate.name())
   assert.match(rotate.description(), /leaving the link itself alive/i)

--- a/src/commands/live-surface.ts
+++ b/src/commands/live-surface.ts
@@ -1,0 +1,131 @@
+/** `soku live-surfaces open | list | revoke | rotate-credential`
+ *
+ * A live surface is a link you hand to a person. They open it in their own
+ * browser and watch the resource change as you work on it, edit it themselves,
+ * and clear the writes that need a human.
+ *
+ * The approval credential is printed once, by `open` and `rotate-credential`,
+ * and never appears in the URL. That separation is the whole point: a link
+ * travels — forwarded, pasted, screenshotted — and a credential travelling with
+ * it would prove nothing while looking like proof. What gets recorded as
+ * "who approved this" depends on it.
+ */
+
+import { Command } from 'commander'
+
+import { apiRequest } from '../http/client.js'
+import { bold, dim, emitSuccess, table } from '../output/envelope.js'
+
+interface OpenedSurface {
+  url: string
+  expiresAt?: string | null
+  approvalCredential?: string | null
+  approvalCredentialNote?: string | null
+}
+
+interface ListedSurface {
+  url: string
+  capabilities: string[]
+  origin: string
+  expiresAt?: string | null
+  lastSeenAt?: string | null
+}
+
+export function registerLiveSurfaceCommands(program: Command): void {
+  const surfaces = program
+    .command('live-surfaces')
+    .description('Hand someone a live link to a resource you are working on')
+
+  surfaces
+    .command('open <resource-id>')
+    .description('Open a link for a resource and print it with its approval code')
+    .option('--type <type>', "Resource kind (default: 'remix_project')", 'remix_project')
+    .option('--read-only', 'Let them watch but not edit')
+    .option('--no-approvals', 'Do not issue an approval code for this link')
+    .option('--ttl-hours <hours>', 'How long the link stays usable (default 12, max 168)')
+    .action(
+      async (
+        resourceId: string,
+        opts: { type: string; readOnly?: boolean; approvals: boolean; ttlHours?: string },
+      ) => {
+        const data = await apiRequest<OpenedSurface>('/api/cli/live-surfaces', {
+          method: 'POST',
+          workspace: true,
+          body: {
+            resource_type: opts.type,
+            resource_id: resourceId,
+            writable: !opts.readOnly,
+            approvable: opts.approvals,
+            ...(opts.ttlHours ? { ttl_hours: Number(opts.ttlHours) } : {}),
+          },
+        })
+        emitSuccess(data, (d) => {
+          const lines = [bold('Link  ') + d.url]
+          if (d.expiresAt) lines.push(dim('Expires ') + d.expiresAt)
+          if (d.approvalCredential) {
+            lines.push('')
+            lines.push(bold('Approval code  ') + d.approvalCredential)
+            // Printed on its own line, away from the URL, because the two must
+            // reach the person by different routes.
+            lines.push(dim(d.approvalCredentialNote ?? 'Give this to the person, not the link.'))
+          }
+          return lines.join('\n')
+        })
+      },
+    )
+
+  surfaces
+    .command('list <resource-id>')
+    .description('Links still open on a resource, so you do not hand out a second one')
+    .option('--type <type>', "Resource kind (default: 'remix_project')", 'remix_project')
+    .action(async (resourceId: string, opts: { type: string }) => {
+      const query = `?resource_id=${encodeURIComponent(resourceId)}&resource_type=${encodeURIComponent(opts.type)}`
+      const data = await apiRequest<{ surfaces: ListedSurface[] }>(
+        `/api/cli/live-surfaces${query}`,
+        { workspace: true },
+      )
+      emitSuccess(data, (d) =>
+        table(
+          d.surfaces.map((s) => ({
+            url: s.url,
+            can: s.capabilities.join(','),
+            origin: s.origin,
+            expires: s.expiresAt ?? '',
+          })),
+          [
+            { key: 'url', header: 'URL' },
+            { key: 'can', header: 'CAN' },
+            { key: 'origin', header: 'OPENED BY' },
+            { key: 'expires', header: 'EXPIRES' },
+          ],
+        ),
+      )
+    })
+
+  surfaces
+    .command('revoke <handle>')
+    .description('Kill a link. Anyone still holding it loses access immediately')
+    .action(async (handle: string) => {
+      emitSuccess(
+        await apiRequest(`/api/cli/live-surfaces/${encodeURIComponent(handle)}`, {
+          method: 'DELETE',
+          workspace: true,
+        }),
+        () => 'Revoked.',
+      )
+    })
+
+  surfaces
+    .command('rotate-credential <handle>')
+    .description('Issue a fresh approval code, leaving the link itself alive')
+    .action(async (handle: string) => {
+      const data = await apiRequest<{ approvalCredential: string }>(
+        `/api/cli/live-surfaces/${encodeURIComponent(handle)}/approval-credential`,
+        { method: 'POST', workspace: true },
+      )
+      // Rotating is for a code that reached the wrong person. Killing the link
+      // as well would cost the right person their work surface for someone
+      // else's mistake, so the two are separate commands.
+      emitSuccess(data, (d) => bold('New approval code  ') + d.approvalCredential)
+    })
+}

--- a/src/commands/live-surface.ts
+++ b/src/commands/live-surface.ts
@@ -1,4 +1,4 @@
-/** `soku live-surfaces open | list | revoke | rotate-credential`
+/** `soku live open | list | revoke | rotate-credential`
  *
  * A live surface is a link you hand to a person. They open it in their own
  * browser and watch the resource change as you work on it, edit it themselves,
@@ -32,9 +32,14 @@ interface ListedSurface {
 }
 
 export function registerLiveSurfaceCommands(program: Command): void {
+  // `live`, not `live-surfaces`. The page a person opens is at `/live/<handle>`,
+  // so that is the word they already have for this; `live-surfaces` is the
+  // internal table's name leaking onto the command line. The server route
+  // stays `/api/cli/live-surfaces` — it is deployed, and nothing is served by
+  // renaming a path nobody types.
   const surfaces = program
-    .command('live-surfaces')
-    .description('Hand someone a live link to a resource you are working on')
+    .command('live')
+    .description('Hand someone a live link to a canvas you are working on')
 
   surfaces
     .command('open <resource-id>')

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { registerContextCommands } from './commands/context.js'
 import { registerEgressCommands } from './commands/egress.js'
 import { registerFilesCommands } from './commands/files.js'
 import { registerGeneratedCommands } from './commands/generated.js'
+import { registerLiveSurfaceCommands } from './commands/live-surface.js'
 import { registerMemoryCommands } from './commands/memory.js'
 import { registerOrgCommands } from './commands/org.js'
 import { registerReviewCommands } from './commands/review.js'
@@ -41,6 +42,7 @@ registerGeneratedCommands(program)
 registerAdsCommands(program)
 registerCallCommand(program)
 registerEgressCommands(program)
+registerLiveSurfaceCommands(program)
 registerReviewCommands(program)
 registerSeoHostingCommands(program)
 registerContextCommands(program)


### PR DESCRIPTION
## Summary

nex-studio 的 `/api/cli/live-surfaces` 路由已经上线（PR #5044），但对应的 CLI 命令一直没有。文档和 dispatcher 的拒绝消息都指向 `soku live-surfaces`，所以照着做的 agent 会被告知去跑一个不存在的命令。

这个 PR 补上它。四个操作，与服务端路由一一对应：

| 命令 | 作用 |
|---|---|
| `open <resource-id>` | 开一条链接，连同审批码一起打印 |
| `list <resource-id>` | 该资源上还开着的链接，避免重复发第二条 |
| `revoke <handle>` | 撤销链接 |
| `rotate-credential <handle>` | 换一个审批码，链接本身不动 |

## 两个刻意的设计

**审批码单独成行、与 URL 分开打印。** 链接是会被转发、粘贴、截图的；随链接同行的审批码证明不了任何事，却看起来像能证明。`decided_by_user_id` 记的是谁，完全取决于这条纪律。

**撤销与轮换是两个命令。** 审批码被错的人看到，不该让对的人失去他的工作面——所以轮换永远不动链接。

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm test` — 183 passed / 0 failed（含本 PR 新增的 3 条）
- [ ] merge 后在 nex-studio 里 bump gitlink

新增测试覆盖：四个子命令都注册且有描述、`open` 的三个开关存在、撤销与轮换确实是两个不同命令。